### PR TITLE
Fix install process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,25 @@
 #-*- coding: utf-8 -*-
 from setuptools import setup, find_packages
-import YaDiskClient
+import codecs
+import os
+import re
 
+
+def read(*parts):
+    return codecs.open(os.path.join(os.path.dirname(__file__), *parts)).read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+    
 setup(
     name='YaDiskClient',
-    version=YaDiskClient.__version__,
+    version=find_version('YaDiskClient', '__init__.py'),
     include_package_data=True,
     py_modules=['YaDiskClient'],
     url='https://github.com/TyVik/YaDiskClient',


### PR DESCRIPTION
In install time there is no required modules, so you cannot import your module from setup.py:

```
  Collecting YaDiskClient==0.3.3 (from -r requirements.txt (line 14))
    Downloading YaDiskClient-0.3.3.tar.gz
      Traceback (most recent call last):
        File "app_main.py", line 75, in run_toplevel
        File "app_main.py", line 581, in run_it
        File "<string>", line 20, in <module>
        File "/tmp/pip-build-72Rdvj/YaDiskClient/setup.py", line 3, in <module>
          import YaDiskClient
        File "YaDiskClient/__init__.py", line 6, in <module>
          from .YaDiskClient import YaDiskException, YaDisk
        File "YaDiskClient/YaDiskClient.py", line 3, in <module>
          import requests
      ImportError: No module named requests
```
